### PR TITLE
Update profile to use github instead of facebook

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,3 +1,5 @@
+import personalInfo from '@/data/personalInfo.json'
+
 export default function Footer() {
   return (
     <footer className="footer">
@@ -18,8 +20,8 @@ export default function Footer() {
           </ul>
 
           <div className="footer-socials">
-            <a href="https://www.facebook.com" target="_blank" className="footer-social">
-              <i className="uil uil-facebook-f"></i>
+            <a href={personalInfo.social.github.url} target="_blank" className="footer-social">
+              <i className={personalInfo.social.github.icon}></i>
             </a>
 
             <a href="https://www.instagram.com" target="_blank" className="footer-social">


### PR DESCRIPTION
Replace the Facebook link and icon in the footer with the GitHub link and icon from `personalInfo.json`.

---
<a href="https://cursor.com/background-agent?bcId=bc-6bc927da-ff1e-49b6-801e-c52ca5528a23">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6bc927da-ff1e-49b6-801e-c52ca5528a23">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

